### PR TITLE
Fix error in parsing of hhea and vhea table and add sanity checks

### DIFF
--- a/RoyT.TrueType/IO/FontReader.cs
+++ b/RoyT.TrueType/IO/FontReader.cs
@@ -75,9 +75,9 @@ namespace RoyT.TrueType.IO
             return data;
         }
 
-        public void Seek(long offset)
+        public void Seek(long offset, SeekOrigin seekOrigin = SeekOrigin.Begin)
         {            
-            this.BaseStream.Seek(offset, SeekOrigin.Begin);
+            this.BaseStream.Seek(offset, seekOrigin);
         }        
     }
 }

--- a/RoyT.TrueType/Tables/HheaTable.cs
+++ b/RoyT.TrueType/Tables/HheaTable.cs
@@ -24,8 +24,8 @@ namespace RoyT.TrueType.Tables
             var caretSlopeRun = reader.ReadInt16BigEndian();
             var caretOffset = reader.ReadInt16BigEndian();
 
-            // Seek over reserved bytes
-            reader.Seek(4);
+            // Seek over 4 reserved int16 fields
+            reader.Seek(8, System.IO.SeekOrigin.Current);
 
             var metricDataFormat = reader.ReadInt16BigEndian();
             var numberOfHMetrics = reader.ReadUInt16BigEndian();

--- a/RoyT.TrueType/Tables/Hmtx/HmtxTable.cs
+++ b/RoyT.TrueType/Tables/Hmtx/HmtxTable.cs
@@ -13,14 +13,18 @@ namespace RoyT.TrueType.Tables.Hmtx
         {
             reader.Seek(entry.Offset);
 
+            int leftSideBearingCount = glyphCount - metricsCount;
+            var expected = 4 * metricsCount + 2 * leftSideBearingCount;
+            if (entry.Length != expected)
+            {
+                throw new Exception("unexpected hmtx table length");
+            }
+
             List<LongHorMetric> hmetrics = new(metricsCount);
             for (int i = 0; i < metricsCount; i++)
             {
                 hmetrics.Add(LongHorMetric.FromReader(reader));
             }
-
-            int leftSideBearingCount = glyphCount - metricsCount;
-            leftSideBearingCount = Math.Max(0, leftSideBearingCount);
 
             List<short> leftSideBearings = new(leftSideBearingCount);
             for (int i = 0; i < leftSideBearingCount; i++)

--- a/RoyT.TrueType/Tables/VheaTable.cs
+++ b/RoyT.TrueType/Tables/VheaTable.cs
@@ -24,8 +24,8 @@ namespace RoyT.TrueType.Tables
             var caretSlopeRun = reader.ReadInt16BigEndian();
             var caretOffset = reader.ReadInt16BigEndian();
 
-            // Seek over reserved bytes
-            reader.Seek(4);
+            // Seek over 4 reserved int16 fields
+            reader.Seek(8, System.IO.SeekOrigin.Current);
 
             var metricDataFormat = reader.ReadInt16BigEndian();
             var numberOfVMetrics = reader.ReadUInt16BigEndian();

--- a/RoyT.TrueType/Tables/Vmtx/LongVerMetric.cs
+++ b/RoyT.TrueType/Tables/Vmtx/LongVerMetric.cs
@@ -11,15 +11,15 @@ namespace RoyT.TrueType.Tables.Vmtx
         {
             return new()
             {
-                AdvanceWidth = reader.ReadUInt16BigEndian(),
+                AdvanceHeight = reader.ReadUInt16BigEndian(),
                 TopSideBearing = reader.ReadInt16BigEndian(),
             };
         }
 
         /// <summary>
-        /// Advance width, in font design units.
+        /// Advance height, in font design units.
         /// </summary>
-        public ushort AdvanceWidth { get; init; }
+        public ushort AdvanceHeight { get; init; }
 
         /// <summary>
         /// Glyph left side bearing, in font design units.

--- a/RoyT.TrueType/Tables/Vmtx/VmtxTable.cs
+++ b/RoyT.TrueType/Tables/Vmtx/VmtxTable.cs
@@ -13,14 +13,17 @@ namespace RoyT.TrueType.Tables.Vmtx
         {
             reader.Seek(entry.Offset);
 
+            int topSideBearingCount = glyphCount - metricsCount;
+            if (entry.Length != metricsCount * 4 + topSideBearingCount * 2)
+            {
+                throw new Exception("unexpected vmtx table length");
+            }
+
             List<LongVerMetric> vmetrics = new(metricsCount);
             for (int i = 0; i < metricsCount; i++)
             {
                 vmetrics.Add(LongVerMetric.FromReader(reader));
             }
-
-            int topSideBearingCount = glyphCount - metricsCount;
-            topSideBearingCount = Math.Max(0, topSideBearingCount);
 
             List<short> topSideBearings = new(topSideBearingCount);
             for (int i = 0; i < topSideBearingCount; i++)


### PR DESCRIPTION
It seems there were two mistakes. In both the hhea and vhea tables the 4 reserved int16 fields were seeked over by only seeking *4 bytes* from the *beginning of the file*.