### PR TITLE
Feature/more features

### DIFF
--- a/RoyT.TrueType.Tests/WindowsFontsTest.cs
+++ b/RoyT.TrueType.Tests/WindowsFontsTest.cs
@@ -2,6 +2,7 @@
 using System.Collections.Generic;
 using System.Globalization;
 using System.IO;
+using System.Linq;
 using RoyT.TrueType.Helpers;
 using RoyT.TrueType.Tables.Name;
 using Xunit;
@@ -14,21 +15,41 @@ namespace RoyT.TrueType.Tests
         /// Integration tests that parses all fonts installed with Windows        
         /// </summary>
         [Fact]
-        public void ShouldParseWindowsFonts()
+        public void ShouldParseTrueTypeFonts()
         {
-            var fonts = new List<TrueTypeFont>();
-            foreach (var file in Directory.EnumerateFiles(@"C:\Windows\Fonts"))
+            List<TrueTypeFont> systemFonts = new();
+            DirectoryInfo fontdir = new(Environment.GetFolderPath(Environment.SpecialFolder.Fonts));
+
+            var fontFiles = fontdir.EnumerateFiles().
+                Where(f => f.Extension.ToLowerInvariant() is ".ttf");
+            foreach (var file in fontFiles)
             {
-                if (file.EndsWith(".ttf") && !file.EndsWith("mstmc.ttf")) // mstmc.ttf is not a regular font file
-                {
-                    var font = TrueTypeFont.FromFile(file);
-                    fonts.Add(font);
-                }
+                var font = TrueTypeFont.FromFile(file.FullName);
+                systemFonts.Add(font);
             }
 
-            Assert.NotEmpty(fonts);
+            Assert.NotEmpty(systemFonts);
         }
 
+        /// <summary>
+        /// Integration tests that parses all fonts installed with Windows        
+        /// </summary>
+        [Fact]
+        public void ShouldParseTrueTypeCollections()
+        {
+            List<TrueTypeFont> systemFonts = new();
+            DirectoryInfo fontdir = new(Environment.GetFolderPath(Environment.SpecialFolder.Fonts));
+
+            var fontCollectionFiles = fontdir.EnumerateFiles().
+                Where(f => f.Extension.ToLowerInvariant() is ".ttc");
+            foreach (var file in fontCollectionFiles)
+            {
+                var fonts = TrueTypeFont.FromCollectionFile(file.FullName);
+                systemFonts.AddRange(fonts);
+            }
+
+            Assert.NotEmpty(systemFonts);
+        }
 
         /// <summary>
         /// Smoke test for checking glyph indices     

--- a/RoyT.TrueType.Tests/WindowsFontsTest.cs
+++ b/RoyT.TrueType.Tests/WindowsFontsTest.cs
@@ -92,8 +92,7 @@ namespace RoyT.TrueType.Tests
         {
             var font = TrueTypeFont.FromFile(@"C:\Windows\Fonts\malgun.ttf");
 
-            Assert.Equal(1, font.VheaTable.MajorVersion);
-            Assert.Equal(0, font.VheaTable.MinorVersion);
+            Assert.Equal(1, font.VheaTable.Version);
         }
 
         [Fact]

--- a/RoyT.TrueType/IO/FontReader.cs
+++ b/RoyT.TrueType/IO/FontReader.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections;
+using System.Data;
 using System.IO;
 using System.Text;
 
@@ -33,7 +34,13 @@ namespace RoyT.TrueType.IO
             var bytes = ReadBigEndian(4);
             return BitConverter.ToUInt32(bytes, 0);
         }
-      
+
+        public long ReadInt64BigEndian()
+        {
+            var bytes = ReadBigEndian(8);
+            return BitConverter.ToInt64(bytes, 0);
+        }
+
         public string ReadAscii(int length)
         {            
             var bytes = this.ReadBytes(length);

--- a/RoyT.TrueType/IO/FontReader.cs
+++ b/RoyT.TrueType/IO/FontReader.cs
@@ -55,12 +55,11 @@ namespace RoyT.TrueType.IO
         /// <summary>
         /// Reads a 32 bit signed fixed point number (16.16)        
         /// </summary>
-        /// <param name="major"></param>
-        /// <param name="minor"></param>
-        public void ReadFixedBigEndian(out short major, out short minor)
-        {            
-            major = ReadInt16BigEndian();
-            minor = ReadInt16BigEndian();
+        public float ReadFixedBigEndian()
+        {
+            var dec = this.ReadInt16BigEndian();
+            var frac = this.ReadUInt16BigEndian();
+            return dec + frac / 65535f;
         }
 
         private byte[] ReadBigEndian(int count)

--- a/RoyT.TrueType/Tables/HeadTable.cs
+++ b/RoyT.TrueType/Tables/HeadTable.cs
@@ -1,0 +1,104 @@
+﻿using RoyT.TrueType.IO;
+
+namespace RoyT.TrueType.Tables
+{
+    /// <summary>
+    /// Font Header Table
+    /// </summary>
+    public record HeadTable
+    {
+        public static HeadTable FromReader(FontReader reader, TableRecordEntry entry)
+        {
+            reader.Seek(entry.Offset);
+
+            var major = reader.ReadUInt16BigEndian();
+            var minor = reader.ReadUInt16BigEndian();
+
+            return new()
+            {
+                MajorVersion = major,
+                MinorVersion = minor,
+                FontRevision = reader.ReadFixedBigEndian(),
+                ChecksumAdjustment = reader.ReadUInt32BigEndian(),
+                MagicNumber = reader.ReadUInt32BigEndian(),
+                Flags = reader.ReadUInt16BigEndian(),
+                UnitsPerEm = reader.ReadUInt16BigEndian(),
+                Created = reader.ReadInt64BigEndian(),
+                Modified = reader.ReadInt64BigEndian(),
+                XMin = reader.ReadInt16BigEndian(),
+                XMax = reader.ReadInt16BigEndian(),
+                YMin = reader.ReadInt16BigEndian(),
+                YMax = reader.ReadInt16BigEndian(),
+                MacStyle = reader.ReadUInt16BigEndian(),
+                LowestRecPPEM = reader.ReadUInt16BigEndian(),
+                FontDirectionHint = reader.ReadInt16BigEndian(),
+                IndexToLocFormat = reader.ReadInt16BigEndian(),
+                GlyphDataFormat = reader.ReadInt16BigEndian(),
+            };
+        }
+
+        // Major version number of the font header table — set to 1.
+        public ushort MajorVersion { get; init; }
+
+        // Minor version number of the font header table — set to 0.
+        public ushort MinorVersion { get; init; }
+
+        // Set by font manufacturer.
+        public float FontRevision { get; init; }
+
+        public uint ChecksumAdjustment { get; init; }
+
+        /// <summary>
+        /// Set to 0x5F0F3CF5.
+        /// </summary>
+        public uint MagicNumber { get; init; }
+
+        public ushort Flags { get; init; }
+
+        /// <summary>
+        /// Set to a value from 16 to 16384.Any value in this range is valid. In fonts that have TrueType outlines, a power of 2 is recommended as this allows performance optimizations in some rasterizers.
+        /// </summary>
+        public ushort UnitsPerEm { get; init; }
+
+        /// <summary>
+        /// Number of seconds since 12:00 midnight that started January 1st 1904 in GMT / UTC time zone.
+        /// </summary>
+        public long Created { get; init; }
+
+        /// <summary>
+        /// Number of seconds since 12:00 midnight that started January 1st 1904 in GMT / UTC time zone.
+        /// </summary>
+        public long Modified { get; init; }
+
+        /// <summary>
+        /// Minimum x coordinate across all glyph bounding boxes.
+        /// </summary>
+        public short XMin { get; init; }
+
+        /// <summary>
+        /// Minimum y coordinate across all glyph bounding boxes.
+        /// </summary>
+        public short YMin { get; init; }
+
+        /// <summary>
+        /// Maximum x coordinate across all glyph bounding boxes.
+        /// </summary>
+        public short XMax { get; init; }
+
+        /// <summary>
+        /// Maximum y coordinate across all glyph bounding boxes.
+        /// </summary>
+        public short YMax { get; init; }
+
+        public ushort MacStyle { get; init; }
+
+        /// <summary>
+        /// Smallest readable size in pixels.
+        /// </summary>
+        public ushort LowestRecPPEM { get; init; }
+
+        public short FontDirectionHint { get; init; }
+        public short IndexToLocFormat { get; init; }
+        public short GlyphDataFormat { get; init; }
+    }
+}

--- a/RoyT.TrueType/Tables/MaxpTable.cs
+++ b/RoyT.TrueType/Tables/MaxpTable.cs
@@ -11,23 +11,21 @@ namespace RoyT.TrueType.Tables
         {
             reader.Seek(entry.Offset);
 
-            reader.ReadFixedBigEndian(out short major, out short minor);
+            var version = reader.ReadFixedBigEndian();
             ushort numGlyphcs = reader.ReadUInt16BigEndian();
 
-            if (major == 0 && minor == 5)
+            if (version == 0.5f)
             {
                 return new()
                 {
-                    MajorVersion = major,
-                    MinorVersion = minor,
+                    Version = version,
                     NumGlyphs = numGlyphcs,
                 };
             }
 
             return new()
             {
-                MajorVersion = major,
-                MinorVersion = minor,
+                Version = version,
                 NumGlyphs = numGlyphcs,
                 MaxPoints = reader.ReadUInt16BigEndian(),
                 MaxContours = reader.ReadUInt16BigEndian(),
@@ -45,8 +43,7 @@ namespace RoyT.TrueType.Tables
             };
         }
 
-        public short MajorVersion { get; init; }
-        public short MinorVersion { get; init; }
+        public float Version { get; init; }
 
         /// <summary>
         /// The number of glyphs in the font.

--- a/RoyT.TrueType/Tables/Name/NameRecord.cs
+++ b/RoyT.TrueType/Tables/Name/NameRecord.cs
@@ -15,7 +15,7 @@ namespace RoyT.TrueType.Tables.Name
 
             if (platformId == Platform.Windows)
             {
-                if (encodingId > 1) // Should be 0 for symbol fonts, 1 for unicode fonts
+                if (encodingId is not (10 or 1 or 0)) // Should be 0 for symbol fonts, 1 for unicode fonts
                 {
                     throw new Exception("Unexpected encoding in name record");
                 }

--- a/RoyT.TrueType/Tables/TrueTypeTableNames.cs
+++ b/RoyT.TrueType/Tables/TrueTypeTableNames.cs
@@ -18,6 +18,11 @@
         public const string maxp = "maxp";
 
         /// <summary>
+        /// Font Header Table
+        /// </summary>
+        public const string head = "head";
+
+        /// <summary>
         /// Naming Table
         /// </summary>
         public const string name = "name";

--- a/RoyT.TrueType/Tables/TtcHeader.cs
+++ b/RoyT.TrueType/Tables/TtcHeader.cs
@@ -1,0 +1,81 @@
+﻿using RoyT.TrueType.IO;
+using System.Collections.Generic;
+
+namespace RoyT.TrueType
+{
+    /// <summary>
+    /// Header for TrueType Collection files
+    /// </summary>
+    public record TtcHeader()
+    {
+        /// <summary>
+        /// Font Collection ID 
+        /// </summary>
+        public string Tag { get; init; }
+
+        /// <summary>
+        /// Major version of the TTC Header
+        /// </summary>
+        public ushort MajorVersion { get; init; }
+
+        /// <summary>
+        /// Minor version of the TTC Header, = 0.
+        /// </summary>
+        public ushort MinorVersion { get; init; }
+
+        /// <summary>
+        /// Number of fonts in TTC
+        /// </summary>
+        public uint NumFonts { get; init; }
+
+        /// <summary>
+        /// Array of offsets to the TableDirectory for each font from the beginning of the file
+        /// </summary>
+        public IReadOnlyList<uint> TableDirectoryOffsets { get; init; }
+
+        /// <summary>
+        /// Tag indicating that a DSIG table exists, 0x44534947 (‘DSIG’) (null if no signature)
+        /// </summary>
+        public uint DsigTag { get; init; }
+
+        /// <summary>
+        /// The length(in bytes) of the DSIG table(null if no signature)
+        /// </summary>
+        public uint DsigLength { get; init; }
+
+        /// <summary>
+        ///  The offset(in bytes) of the DSIG table from the beginning of the TTC file (null if no signature)
+        /// </summary>
+        public uint DsigOffset { get; init; }
+
+        public static TtcHeader Parse(FontReader reader)
+        {
+            TtcHeader result = new()
+            {
+                Tag = reader.ReadAscii(4),
+                MajorVersion = reader.ReadUInt16BigEndian(),
+                MinorVersion = reader.ReadUInt16BigEndian(),
+                NumFonts = reader.ReadUInt32BigEndian(),
+            };
+
+            List<uint> offsets = new();
+            for (int i = 0; i < result.NumFonts; i++)
+            {
+                offsets.Add(reader.ReadUInt32BigEndian());
+            }
+
+            if (result.MajorVersion == 1)
+            {
+                return result with { TableDirectoryOffsets = offsets };
+            }
+
+            return result with
+            {
+                TableDirectoryOffsets = offsets,
+                DsigTag = reader.ReadUInt32BigEndian(),
+                DsigLength = reader.ReadUInt32BigEndian(),
+                DsigOffset = reader.ReadUInt32BigEndian(),
+            };
+        }
+    }
+}

--- a/RoyT.TrueType/Tables/VheaTable.cs
+++ b/RoyT.TrueType/Tables/VheaTable.cs
@@ -11,7 +11,7 @@ namespace RoyT.TrueType.Tables
         {
             reader.Seek(entry.Offset);
 
-            reader.ReadFixedBigEndian(out short major, out short minor);
+            var version = reader.ReadFixedBigEndian();
 
             var ascender = reader.ReadInt16BigEndian();
             var descender = reader.ReadInt16BigEndian();
@@ -32,8 +32,7 @@ namespace RoyT.TrueType.Tables
 
             return new VheaTable()
             {
-                MajorVersion = major,
-                MinorVersion = minor,
+                Version = version,
                 Ascender = ascender,
                 Descender = descender,
                 LineGap = lineGap,
@@ -52,14 +51,9 @@ namespace RoyT.TrueType.Tables
         public static VheaTable Empty => new VheaTable();
 
         /// <summary>
-        /// Major version number of the vertical header table
+        /// Version number of the vertical header table
         /// </summary>
-        public short MajorVersion { get; init; }
-
-        /// <summary>
-        /// Minor version number of the vertical header table
-        /// </summary>
-        public short MinorVersion { get; init; }
+        public float Version { get; init; }
 
         /// <summary>
         /// The vertical typographic ascender for this font. It is the distance in FUnits from the vertical

--- a/RoyT.TrueType/TrueTypeFont.cs
+++ b/RoyT.TrueType/TrueTypeFont.cs
@@ -22,6 +22,7 @@ namespace RoyT.TrueType
 
                 var cmap = ReadCmapTable(path, reader, entries);
                 var name = ReadNameTable(path, reader, entries);
+                var head = ReadHeadTable(path, reader, entries);
                 var maxp = ReadMaxpTable(path, reader, entries);
                 var os2 = ReadOs2Table(reader, entries);
                 var kern = ReadKernTable(reader, entries);
@@ -33,6 +34,7 @@ namespace RoyT.TrueType
                 return new TrueTypeFont(path, offsetTable, entries, cmap, name, kern)
                 {
                     Os2Table = os2,
+                    HeadTable = head,
                     MaxpTable = maxp,
                     HheaTable = hhea,
                     HmtxTable = hmtx,
@@ -93,6 +95,17 @@ namespace RoyT.TrueType
 
             throw new Exception(
                 $"Font {path} does not contain a Name Table (name)");
+        }
+
+        private static HeadTable ReadHeadTable(string path, FontReader reader, IReadOnlyDictionary<string, TableRecordEntry> entries)
+        {
+            if (entries.TryGetValue(TrueTypeTableNames.head, out var entry))
+            {
+                return HeadTable.FromReader(reader, entry);
+            }
+
+            throw new Exception(
+                $"Font {path} does not contain a Font Header Table (head)");
         }
 
         private static MaxpTable ReadMaxpTable(string path, FontReader reader, IReadOnlyDictionary<string, TableRecordEntry> entries)
@@ -195,6 +208,11 @@ namespace RoyT.TrueType
         /// Consists of a set of metrics and other data that are required in OpenType fonts
         /// </summary>
         public Os2Table Os2Table { get; init; }
+
+        /// <summary>
+        /// Consists of global information about the font
+        /// </summary>
+        public HeadTable HeadTable { get; init; }
 
         /// <summary>
         /// Contains the memory requirements for this font.


### PR DESCRIPTION
The fixed-point number parsing was wrong. If you ask me it's totally inappropriate to store versions as such, but I don't write the standards. Version 6.68 for malgun.ttf for instance is now parsed as 6.680003.

Also added support for truetype collections #4 and the head table, which is essential for it's `UnitsPerEm` value. 